### PR TITLE
Add vLLM deployment for ai-polishing model

### DIFF
--- a/k8s/foundation/ai-polishing/deployment.yaml
+++ b/k8s/foundation/ai-polishing/deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-polishing
+  namespace: foundation
+  labels:
+    app.kubernetes.io/instance: ai-polishing
+    app.kubernetes.io/name: ai-polishing
+    app.kubernetes.io/component: vllm-model
+    app.kubernetes.io/managed-by: automated-pipeline
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: ai-polishing
+      app.kubernetes.io/name: ai-polishing
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: ai-polishing
+        app.kubernetes.io/name: ai-polishing
+        app.kubernetes.io/component: vllm-model
+        app: vllm
+    spec:
+      containers:
+        - name: ai-polishing
+          image: vllm/vllm-openai:latest
+          args:
+            - --model
+            - /models/ai-polishing
+            - --served-model-name
+            - ai-polishing
+            - --port
+            - 8000
+            - --tensor-parallel-size
+            - 4
+            - --enable-auto-tool-choice
+          env:
+            # No environment variables
+          ports:
+            - containerPort: 8000
+              name: http
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 2
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              nvidia.com/gpu: "4"
+              memory: "32Gi"
+              cpu: "8"
+            requests:
+              nvidia.com/gpu: "4"
+              memory: "16Gi"
+              cpu: "4"
+          securityContext:
+            capabilities:
+              add:
+                - SYS_PTRACE
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - name: model-storage
+              mountPath: /models
+              readOnly: true
+            - name: shm
+              mountPath: /dev/shm
+      volumes:
+        - name: model-storage
+          persistentVolumeClaim:
+            claimName: ai-blob-pvc
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 8Gi
+      nodeSelector:
+        accelerator: nvidia-gpu
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule

--- a/k8s/foundation/ai-polishing/kustomization.yaml
+++ b/k8s/foundation/ai-polishing/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: vllm-deployment
+resources:
+  - deployment.yaml
+  - service.yaml
+  - servicemonitor.yaml
+commonLabels:
+  app.kubernetes.io/part-of: vllm-platform
+patches:
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: add
+        path: /metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration
+        value: "managed-by-kustomize"

--- a/k8s/foundation/ai-polishing/service.yaml
+++ b/k8s/foundation/ai-polishing/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-polishing
+  namespace: foundation
+  labels:
+    app.kubernetes.io/instance: ai-polishing
+    app.kubernetes.io/name: ai-polishing
+    app.kubernetes.io/component: vllm-model
+  annotations:
+    created-by: "Automated By Pipeline"
+    team: "AI Team"
+    exposure-type: internal
+    creator-email: runtest1122@gmail.com
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8000
+      name: http
+  selector:
+    app.kubernetes.io/instance: ai-polishing
+    app.kubernetes.io/name: ai-polishing

--- a/k8s/foundation/ai-polishing/servicemonitor.yaml
+++ b/k8s/foundation/ai-polishing/servicemonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ai-polishing
+  namespace: foundation
+  labels:
+    team: observability
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: ai-polishing
+      app.kubernetes.io/name: ai-polishing
+  namespaceSelector:
+    matchNames:
+      - foundation
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      honorLabels: false


### PR DESCRIPTION
## Overview
This PR adds a new vLLM deployment for the ai-polishing model.

**Created by:** run test (runtest1122@gmail.com)

## Changes
- Kubernetes Deployment with health probes
- Service configuration with LoadBalancer
- Kustomization for GitOps
- ServiceMonitor for Prometheus metrics
- Authenticated deployment via Keycloak

## Testing
- [ ] Verify deployment starts successfully  
- [ ] Test model API endpoints
- [ ] Confirm metrics collection

## Security
- Deployment created by authenticated user via Keycloak
- User context tracked in resource annotations